### PR TITLE
Address YAMLLoadWarning: calling yaml.load() without Loader

### DIFF
--- a/j2cli_3/context.py
+++ b/j2cli_3/context.py
@@ -79,7 +79,7 @@ def _parse_yaml(data_string):
         $ j2 config.j2 data.yml
         $ cat data.yml | j2 --format=yaml config.j2
     """
-    return yaml.load(data_string)
+    return yaml.load(data_string, Loader=yaml.FullLoader)
 
 def _parse_env(data_string):
     """ Data input from environment variables.


### PR DESCRIPTION
PyYaml is switching to a safer mechanism for loading yaml (which avoids python injection attacks). The fix is straight-forward and described [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

The `FullLoader` is called automatically after the warning is issued so there will be NO change in functionality.