### PR TITLE
Preserve trailing newline at end of file

### DIFF
--- a/j2cli_3/cli.py
+++ b/j2cli_3/cli.py
@@ -43,6 +43,7 @@ def render_template(cwd, template_path, context):
     """
     env = jinja2.Environment(
         loader=FilePathLoader(cwd),
+        keep_trailing_newline=True,
         undefined=jinja2.StrictUndefined # raises errors for undefined variables
     )
 


### PR DESCRIPTION
jinja2 does **not** preserve trailing newlines by default which is a weird choice for a template engine. Given that the purpose of j2cli_3 is to work as a command-line template renderer it makes sense for it to **not** make changes that are not explicitly specified.

The current behavior introduced a difficult to diagnose bug in my usage.